### PR TITLE
ButtonPage components

### DIFF
--- a/Shortcuts.Web/Components/ButtonsContainer.razor
+++ b/Shortcuts.Web/Components/ButtonsContainer.razor
@@ -1,0 +1,13 @@
+﻿<PageTitle>@Title</PageTitle>
+
+    <h1 class="display-1 text-center">@Title</h1>
+<div class="row justify-content-between">
+    @ChildContent
+</div>
+
+@code {
+    [Parameter]
+    public string Title { get; set; }
+    [Parameter, EditorRequired]
+    public RenderFragment ChildContent { get; set; } = default!;
+}

--- a/Shortcuts.Web/Components/Layout/ButtonsPageLayout.razor
+++ b/Shortcuts.Web/Components/Layout/ButtonsPageLayout.razor
@@ -1,0 +1,8 @@
+﻿@inherits LayoutComponentBase
+
+<div class="container">
+    <div class="text-end">
+        <a class="text-uppercase link-light link-offset-2 link-underline link-underline-opacity-0 link-underline-opacity-75-hover" href="/">Back</a>
+    </div>
+    @Body
+</div>

--- a/Shortcuts.Web/Components/Pages/Krita.razor
+++ b/Shortcuts.Web/Components/Pages/Krita.razor
@@ -1,45 +1,17 @@
 ﻿@page "/Krita"
 @rendermode InteractiveServer
 @inject KritaService krita
+@layout ButtonsPageLayout
 
-<PageTitle>Krita Shortcuts</PageTitle>
-<div class="container">
-<div class="text-end">
-    <a class="text-uppercase link-light link-offset-2 link-underline link-underline-opacity-0 link-underline-opacity-75-hover" href="/">Back</a>
-</div>
-    <h1 class="display-1 text-center">Krita Shortcuts</h1>
-    <div class="row justify-content-between">
-        <div class="col-6 col-md p-2">
-            <button @onclick="Undo" class="btn btn-danger btn-lg py-5 text-uppercase fw-bold w-100">
-                Undo
-            </button>
-        </div>
-
-        <div class="col-6 col-md p-2">
-            <button @onclick="Redo" class="btn btn-primary btn-lg py-5 text-uppercase fw-bold w-100">
-                Redo
-            </button>
-        </div>
-        <div class="col-12 col-md p-2">
-            <button @onclick="Erase" class="btn btn-info btn-lg py-5 text-uppercase fw-bold w-100">
-                Erase
-            </button>
-        </div>
-        <div class="col-12 col-md p-2">
-            <button @onclick="ClearLayer" class="btn btn-warning btn-lg py-5 text-uppercase fw-bold w-100">
-                Clear Layer
-            </button>
-        </div>
-        <div class="col-12 col-md p-2">
-            <button @onclick="FullScreen" class="btn btn-secondary btn-lg py-5 text-uppercase fw-bold w-100">
-                Full Screen
-            </button>
-        </div>
-    </div>
-</div>
+<ButtonsContainer Title="Krita Shortcuts">
+    <ShortucutButton Text="Undo" @onclick="Undo" Col="6" Color="danger" />
+    <ShortucutButton Text="Redo" @onclick="Redo" Col="6" Color="primary" />
+    <ShortucutButton Text="Erase" @onclick="Erase" Col="12" Color="info" />
+    <ShortucutButton Text="Clear Layer" @onclick="ClearLayer" Col="12" Color="warning" />
+    <ShortucutButton Text="Full Screen" @onclick="FullScreen" Col="12" Color="secondary" />
+</ButtonsContainer>
 
 @code {
-
     private void Undo()
     {
         krita.Undo();

--- a/Shortcuts.Web/Components/ShortucutButton.razor
+++ b/Shortcuts.Web/Components/ShortucutButton.razor
@@ -1,0 +1,17 @@
+﻿<div class="col-@Col col-md p-2">
+    <button @attributes="AdditionalAttributes" class="btn btn-@Color btn-lg py-5 text-uppercase fw-bold w-100">
+        @Text
+    </button>
+</div>
+
+@code {
+    [Parameter]
+    public string Text { get; set; } = "";
+    [Parameter]
+    public int Col { get; set; } = 12;
+    [Parameter]
+    public string Color { get; set; } = "primary";
+
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object>? AdditionalAttributes { get; set; }
+}

--- a/Shortcuts.Web/Components/_Imports.razor
+++ b/Shortcuts.Web/Components/_Imports.razor
@@ -8,4 +8,5 @@
 @using Microsoft.JSInterop
 @using Shortcuts.Web
 @using Shortcuts.Web.Components
+@using Shortcuts.Web.Components.Layout
 @using Shortcuts.Web.Services


### PR DESCRIPTION
Krita page was split into several components to make creating uniform look across different ButtonPages easier.
There is now a ButtonPageLayout that can be used instead of MainLayout.
Each button can now be created using ShortcutButton component.
Buttons should be put inside ButtonsContainer that also hadles PageTitle and displaying h1 heading on the page.